### PR TITLE
Improve live tests

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -1,11 +1,17 @@
-on: [push, pull_request]
-name: Test
+on: 
+  pull_request:
+  push:
+    branches: main
+  schedule:
+    - cron: '6 15 * * 1' 
+
+name: live tests
 jobs:
   test:
     strategy:
       matrix:
         go-version: [1.15.x, 1.16.x]
-        os: [ubuntu-latest, macos-latest, windows-latest]
+        os: [ubuntu-latest]
     runs-on: ${{ matrix.os }}
     steps:
     - name: Install Go

--- a/README.md
+++ b/README.md
@@ -1,3 +1,5 @@
+![live tests](https://github.com/tech-branch/glassnode/actions/workflows/test.yml/badge.svg)
+
 ### What's that?
 
 API wrapper for Glassnode on-chain market intelligence data
@@ -118,3 +120,11 @@ opts := APIOptionsList{
 ```
 
 Please see the tests file for complete examples.
+
+### Tests
+
+Live tests will skip if there's no API key in the env vars.
+
+```
+export GLASSNODE_API_KEY=yourapikeygoeshere
+```

--- a/main_test.go
+++ b/main_test.go
@@ -2,8 +2,8 @@ package glassnode
 
 import (
 	"context"
+	"os"
 	"testing"
-	"time"
 )
 
 func Test_tvconv(t *testing.T) {
@@ -88,8 +88,8 @@ func Test_toconv(t *testing.T) {
 }
 
 func Test_liveintegration(t *testing.T) {
-	apik := "x"
-	if apik == "x" {
+	apik := os.Getenv("GLASSNODE_API_KEY")
+	if apik == "" {
 		t.Log("live API Key is required for this test")
 		t.SkipNow()
 	}
@@ -114,15 +114,15 @@ func Test_liveintegration(t *testing.T) {
 
 	e := d.([]TimeValue)
 
-	for i := 0; i < len(e); i++ {
-		t.Logf("%f\n", e[i].Value)
-		t.Log(time.Unix(e[i].Time, 0))
+	if e[0].Value > 2 || e[0].Value < 0 {
+		t.Log("SOPR should be between 0 and 2")
+		t.Fail()
 	}
 }
 
 func Test_liveintegration_directmappings(t *testing.T) {
-	apik := "x"
-	if apik == "x" {
+	apik := os.Getenv("GLASSNODE_API_KEY")
+	if apik == "" {
 		t.Log("live API Key is required for this test")
 		t.SkipNow()
 	}
@@ -153,11 +153,6 @@ func Test_liveintegration_directmappings(t *testing.T) {
 	if e[0].Options["ma9"] < 100 {
 		t.Logf("ma9 val should be greater than %f but is %f", 100.0, e[0].Options["ma9"])
 		t.Fail()
-	}
-
-	for i := 0; i < len(e); i++ {
-		t.Logf("%f\n", e[i].Options["ma9"])
-		t.Log(time.Unix(e[i].Time, 0))
 	}
 }
 


### PR DESCRIPTION
Prior to this change, live tests had to be executed manually

This change replaces the manual mechanism with an environment-variable-based one.

Now you can do: 

```
export GLASSNODE_API_KEY=yourapikeygoeshere
go test -v
```

Instead of having to put the key manually in the codebase 

In addition, live tests will be performed weekly to flag up if the module runs out of sync with Glassnode API. 